### PR TITLE
more robust way to get MYDIR

### DIFF
--- a/rust-ctags
+++ b/rust-ctags
@@ -5,7 +5,7 @@ if [[ "$1" == "" ]]; then
     exit 1
 fi
 
-MYDIR="$(dirname $1)"
+MYDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CTAGS="$MYDIR/ctags.rust"
 
 if [ ! -f "$CTAGS" ]; then


### PR DESCRIPTION
and now something like this works

    ~/src/rust (master)$ ~/src/rust-etags/rust-ctags src/lib*
