### PR TITLE
Fix selfpath resolving

### DIFF
--- a/rust-ctags
+++ b/rust-ctags
@@ -8,6 +8,13 @@ fi
 MYDIR="$(dirname $0)"
 CTAGS="$MYDIR/ctags.rust"
 
+# case when rust-ctags in PATH
+if [ ! -f "$CTAGS" ]; then
+  ME="$(readlink $0)" # check if it symlinked
+  ME="${ME:-$0}" # or just $0 by default
+  CTAGS="$(dirname $ME)/ctags.rust"
+fi
+
 if [ ! -f "$CTAGS" ]; then
   echo ctags.rust definition not found
   echo Searched at: "$CTAGS"

--- a/rust-ctags
+++ b/rust-ctags
@@ -5,7 +5,7 @@ if [[ "$1" == "" ]]; then
     exit 1
 fi
 
-MYDIR="$(dirname $1)"
+MYDIR="$(dirname $0)"
 CTAGS="$MYDIR/ctags.rust"
 
 if [ ! -f "$CTAGS" ]; then


### PR DESCRIPTION
Fix resolving self-path and search `ctags.rust` nearby in cases:
- if `rust-ctags` in `PATH` and called out there somewhere;
- fix the same case for symlinked `rust-ctags`